### PR TITLE
fix ignore block comment corner case

### DIFF
--- a/comment_wrap.go
+++ b/comment_wrap.go
@@ -83,7 +83,7 @@ func processComments(fset *token.FileSet, comments []*ast.CommentGroup, maxComme
 				lineNumber := file.Position(cg.List[cIdx].Pos()).Line
 
 				// Block comments are ignored
-				if strings.Contains(c.Text, "/*") || strings.Contains(c.Text, "*/") {
+				if strings.HasPrefix(c.Text, "/*") || strings.HasSuffix(c.Text, "*/") {
 					if !write {
 						log.Printf("%v:%v ignoring block comment\n", file.Name(), lineNumber)
 					}


### PR DESCRIPTION
Block-level comment symbols may be hidden in single-line comments. see below:

```go
// Test This is a simplest comment /*for*/ test
func Test() {}
```